### PR TITLE
Add OpenShift Dockerfile

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,0 +1,12 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
+WORKDIR /go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
+COPY . .
+RUN make
+
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
+# Get mkfs & blkid
+RUN yum update -y && \
+    yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux && \
+    yum clean all && rm -rf /var/cache/yum/*
+COPY --from=builder /go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver  /usr/bin/
+ENTRYPOINT ["/usr/bin/gce-pd-csi-driver"]


### PR DESCRIPTION
Adding Dockerfile for OpenShift. Not adding .rhel7/.rhel8 extension, as it is controlled by the base image and not the extension (4.6 is RHEL8, I believe).

cc @openshift/storage 