### PR TITLE
UPSTREAM: <carry>: Skip Windows build

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,7 +1,8 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
 COPY . .
-RUN make
+# Skip Windows driver build
+RUN make gce-pd-driver
 
 FROM registry.svc.ci.openshift.org/ocp/4.7:base
 # Get mkfs & blkid


### PR DESCRIPTION
ART tooling / base images do not support it.
cc @openshift/storage 