### PR TITLE
Copy scsi_id binary to dir that driver expects

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -8,6 +8,8 @@ FROM registry.svc.ci.openshift.org/ocp/4.7:base
 # Get mkfs & blkid
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux && \
-    yum clean all && rm -rf /var/cache/yum/*
+    yum clean all && rm -rf /var/cache/yum/* && \
+    mkdir -p /lib/udev_containerized && cp /usr/lib/udev/scsi_id /lib/udev_containerized/scsi_id # The driver assumes this path
+
 COPY --from=builder /go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver  /usr/bin/
 ENTRYPOINT ["/usr/bin/gce-pd-csi-driver"]


### PR DESCRIPTION
The CSI driver assumes `scsi_id` is located at `/lib/udev_containerized/scsi_id`. Something similar to this is done in the upstream Dockerfile, but somehow we missed it.

CC @openshift/storage 
/assign @jsafrane 