### PR TITLE
Fix scsi_id installation

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -7,7 +7,7 @@ RUN make gce-pd-driver
 FROM registry.svc.ci.openshift.org/ocp/4.7:base
 # Get mkfs & blkid
 RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux && \
+    yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux systemd-udev && \
     yum clean all && rm -rf /var/cache/yum/* && \
     mkdir -p /lib/udev_containerized && cp /usr/lib/udev/scsi_id /lib/udev_containerized/scsi_id # The driver assumes this path
 


### PR DESCRIPTION
systemd-udev must be installed to get the scsi_id binary.

Fixes this build error:

```
2020-11-23 07:36:50,815 - atomic_reactor.plugins.imagebuilder - INFO - cp: cannot stat '/usr/lib/udev/scsi_id': No such file or directory
```

BTW, why the driver needs extra copy of scsi_id?
Edit: because /lib/udev comes from the host, see https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/459

cc @openshift/storage 