### PR TITLE
UPSTREAM: 693: Add CLI option to label the PD disks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/apimachinery v0.18.0
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
+	k8s.io/component-base v0.18.0
 	k8s.io/klog v1.0.0
 	k8s.io/kubernetes v1.18.0
 	k8s.io/test-infra v0.0.0-20200115230622-70a5174aa78d

--- a/go.sum
+++ b/go.sum
@@ -1146,6 +1146,7 @@ k8s.io/client-go v0.18.0/go.mod h1:uQSYDYs4WhVZ9i6AIoEZuwUggLVEF64HOD37boKAtF8=
 k8s.io/cloud-provider v0.18.0/go.mod h1:ZBq1FhoJ+XoQ8JYBYoyx81LS3JV0RAW/UmHf/6w9E6k=
 k8s.io/cluster-bootstrap v0.18.0/go.mod h1:xSe+bOZ3asS/ciT91ESQYGhjOql43aBETfvbCzNvad8=
 k8s.io/code-generator v0.18.0/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
+k8s.io/component-base v0.18.0 h1:I+lP0fNfsEdTDpHaL61bCAqTZLoiWjEEP304Mo5ZQgE=
 k8s.io/component-base v0.18.0/go.mod h1:u3BCg0z1uskkzrnAKFzulmYaEpZF7XC9Pf/uFyb1v2c=
 k8s.io/cri-api v0.18.0/go.mod h1:OJtpjDvfsKoLGhvcc0qfygved0S0dGX56IJzPbqTG1s=
 k8s.io/csi-translation-lib v0.18.0/go.mod h1:iF8TE4ACSaPqN1qxmiIjvcU1A8VgkOrpcFGD7Z0hVu0=

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -54,16 +54,20 @@ type DiskParameters struct {
 	// Values: {map[string]string}
 	// Default: ""
 	Tags map[string]string
+	// Values: {map[string]string}
+	// Default: ""
+	Labels map[string]string
 }
 
 // ExtractAndDefaultParameters will take the relevant parameters from a map and
 // put them into a well defined struct making sure to default unspecified fields
-func ExtractAndDefaultParameters(parameters map[string]string, driverName string) (DiskParameters, error) {
+func ExtractAndDefaultParameters(parameters map[string]string, driverName string, extraVolumeLabels map[string]string) (DiskParameters, error) {
 	p := DiskParameters{
 		DiskType:             "pd-standard",           // Default
 		ReplicationType:      replicationTypeNone,     // Default
 		DiskEncryptionKMSKey: "",                      // Default
 		Tags:                 make(map[string]string), // Default
+		Labels:               make(map[string]string), // Default
 	}
 
 	for k, v := range parameters {
@@ -95,6 +99,9 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 	}
 	if len(p.Tags) > 0 {
 		p.Tags[tagKeyCreatedBy] = driverName
+	}
+	for k, v := range extraVolumeLabels {
+		p.Labels[k] = v
 	}
 	return p, nil
 }

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -25,79 +25,105 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 	tests := []struct {
 		name         string
 		parameters   map[string]string
+		labels       map[string]string
 		expectParams DiskParameters
 		expectErr    bool
 	}{
 		{
 			name:       "defaults",
 			parameters: map[string]string{},
+			labels:     map[string]string{},
 			expectParams: DiskParameters{
 				DiskType:             "pd-standard",
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "",
 				Tags:                 make(map[string]string),
+				Labels:               make(map[string]string),
 			},
 		},
 		{
 			name:       "specified empties",
 			parameters: map[string]string{ParameterKeyType: "", ParameterKeyReplicationType: "", ParameterKeyDiskEncryptionKmsKey: ""},
+			labels:     map[string]string{},
 			expectParams: DiskParameters{
 				DiskType:             "pd-standard",
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "",
 				Tags:                 make(map[string]string),
+				Labels:               make(map[string]string),
 			},
 		},
 		{
 			name:       "random keys",
 			parameters: map[string]string{ParameterKeyType: "", "foo": "", ParameterKeyDiskEncryptionKmsKey: ""},
+			labels:     map[string]string{},
 			expectErr:  true,
 		},
 		{
 			name:       "real values",
 			parameters: map[string]string{ParameterKeyType: "pd-ssd", ParameterKeyReplicationType: "regional-pd", ParameterKeyDiskEncryptionKmsKey: "foo/key"},
+			labels:     map[string]string{},
 			expectParams: DiskParameters{
 				DiskType:             "pd-ssd",
 				ReplicationType:      "regional-pd",
 				DiskEncryptionKMSKey: "foo/key",
 				Tags:                 make(map[string]string),
+				Labels:               make(map[string]string),
 			},
 		},
 		{
 			name:       "real values, checking balanced pd",
 			parameters: map[string]string{ParameterKeyType: "pd-balanced", ParameterKeyReplicationType: "regional-pd", ParameterKeyDiskEncryptionKmsKey: "foo/key"},
+			labels:     map[string]string{},
 			expectParams: DiskParameters{
 				DiskType:             "pd-balanced",
 				ReplicationType:      "regional-pd",
 				DiskEncryptionKMSKey: "foo/key",
 				Tags:                 make(map[string]string),
+				Labels:               make(map[string]string),
 			},
 		},
 		{
 			name:       "partial spec",
 			parameters: map[string]string{ParameterKeyDiskEncryptionKmsKey: "foo/key"},
+			labels:     map[string]string{},
 			expectParams: DiskParameters{
 				DiskType:             "pd-standard",
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "foo/key",
 				Tags:                 make(map[string]string),
+				Labels:               make(map[string]string),
 			},
 		},
 		{
 			name:       "tags",
 			parameters: map[string]string{ParameterKeyPVCName: "testPVCName", ParameterKeyPVCNamespace: "testPVCNamespace", ParameterKeyPVName: "testPVName"},
+			labels:     map[string]string{},
 			expectParams: DiskParameters{
 				DiskType:             "pd-standard",
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "",
 				Tags:                 map[string]string{tagKeyCreatedForClaimName: "testPVCName", tagKeyCreatedForClaimNamespace: "testPVCNamespace", tagKeyCreatedForVolumeName: "testPVName", tagKeyCreatedBy: "testDriver"},
+				Labels:               make(map[string]string),
+			},
+		},
+		{
+			name:       "labels",
+			parameters: map[string]string{},
+			labels:     map[string]string{"label-1": "label-value-1", "label-2": "label-value-2"},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "",
+				Tags:                 map[string]string{},
+				Labels:               map[string]string{"label-1": "label-value-1", "label-2": "label-value-2"},
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p, err := ExtractAndDefaultParameters(tc.parameters, "testDriver")
+			p, err := ExtractAndDefaultParameters(tc.parameters, "testDriver", tc.labels)
 			if gotErr := err != nil; gotErr != tc.expectErr {
 				t.Fatalf("ExtractAndDefaultParameters(%+v) = %v; expectedErr: %v", tc.parameters, err, tc.expectErr)
 			}

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -481,6 +481,7 @@ func (cloud *CloudProvider) insertZonalDisk(
 		SizeGb:      common.BytesToGb(capBytes),
 		Description: description,
 		Type:        cloud.GetDiskTypeURI(volKey, params.DiskType),
+		Labels:      params.Labels,
 	}
 
 	if snapshotID != "" {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -107,7 +107,7 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 
 	// Apply Parameters (case-insensitive). We leave validation of
 	// the values to the cloud provider.
-	params, err := common.ExtractAndDefaultParameters(req.GetParameters(), gceCS.Driver.name)
+	params, err := common.ExtractAndDefaultParameters(req.GetParameters(), gceCS.Driver.name, gceCS.Driver.extraVolumeLabels)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to extract parameters: %v", err)
 	}
@@ -475,7 +475,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 	}
 
 	// Validate the disk parameters match the disk we GET
-	params, err := common.ExtractAndDefaultParameters(req.GetParameters(), gceCS.Driver.name)
+	params, err := common.ExtractAndDefaultParameters(req.GetParameters(), gceCS.Driver.name, gceCS.Driver.extraVolumeLabels)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to extract parameters: %v", err)
 	}

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -29,8 +29,9 @@ import (
 )
 
 type GCEDriver struct {
-	name          string
-	vendorVersion string
+	name              string
+	vendorVersion     string
+	extraVolumeLabels map[string]string
 
 	ids *GCEIdentityServer
 	ns  *GCENodeServer
@@ -45,7 +46,7 @@ func GetGCEDriver() *GCEDriver {
 	return &GCEDriver{}
 }
 
-func (gceDriver *GCEDriver) SetupGCEDriver(name, vendorVersion string, identityServer *GCEIdentityServer, controllerServer *GCEControllerServer, nodeServer *GCENodeServer) error {
+func (gceDriver *GCEDriver) SetupGCEDriver(name, vendorVersion string, extraVolumeLabels map[string]string, identityServer *GCEIdentityServer, controllerServer *GCEControllerServer, nodeServer *GCENodeServer) error {
 	if name == "" {
 		return fmt.Errorf("Driver name missing")
 	}
@@ -77,6 +78,7 @@ func (gceDriver *GCEDriver) SetupGCEDriver(name, vendorVersion string, identityS
 
 	gceDriver.name = name
 	gceDriver.vendorVersion = vendorVersion
+	gceDriver.extraVolumeLabels = extraVolumeLabels
 	gceDriver.ids = identityServer
 	gceDriver.cs = controllerServer
 	gceDriver.ns = nodeServer

--- a/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
@@ -44,7 +44,7 @@ func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) 
 	vendorVersion := "test-vendor"
 	gceDriver := GetGCEDriver()
 	controllerServer := NewControllerServer(gceDriver, cloudProvider)
-	err := gceDriver.SetupGCEDriver(driver, vendorVersion, nil, controllerServer, nil)
+	err := gceDriver.SetupGCEDriver(driver, vendorVersion, nil, nil, controllerServer, nil)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}

--- a/pkg/gce-pd-csi-driver/identity_test.go
+++ b/pkg/gce-pd-csi-driver/identity_test.go
@@ -26,7 +26,7 @@ func TestGetPluginInfo(t *testing.T) {
 	vendorVersion := "test-vendor"
 	gceDriver := GetGCEDriver()
 	identityServer := NewIdentityServer(gceDriver)
-	err := gceDriver.SetupGCEDriver(driver, vendorVersion, identityServer, nil, nil)
+	err := gceDriver.SetupGCEDriver(driver, vendorVersion, nil, identityServer, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestGetPluginInfo(t *testing.T) {
 func TestGetPluginCapabilities(t *testing.T) {
 	gceDriver := GetGCEDriver()
 	identityServer := NewIdentityServer(gceDriver)
-	err := gceDriver.SetupGCEDriver(driver, "test-vendor", identityServer, nil, nil)
+	err := gceDriver.SetupGCEDriver(driver, "test-vendor", nil, identityServer, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestGetPluginCapabilities(t *testing.T) {
 func TestProbe(t *testing.T) {
 	gceDriver := GetGCEDriver()
 	identityServer := NewIdentityServer(gceDriver)
-	err := gceDriver.SetupGCEDriver(driver, "test-vendor", identityServer, nil, nil)
+	err := gceDriver.SetupGCEDriver(driver, "test-vendor", nil, identityServer, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -43,7 +43,7 @@ func getTestGCEDriverWithCustomMounter(t *testing.T, mounter *mount.SafeFormatAn
 func getCustomTestGCEDriver(t *testing.T, mounter *mount.SafeFormatAndMount, deviceUtils mountmanager.DeviceUtils, metaService metadataservice.MetadataService) *GCEDriver {
 	gceDriver := GetGCEDriver()
 	nodeServer := NewNodeServer(gceDriver, mounter, deviceUtils, metaService, mountmanager.NewFakeStatter(mounter))
-	err := gceDriver.SetupGCEDriver(driver, "test-vendor", nil, nil, nodeServer)
+	err := gceDriver.SetupGCEDriver(driver, "test-vendor", nil, nil, nil, nodeServer)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}
@@ -54,7 +54,7 @@ func getTestBlockingGCEDriver(t *testing.T, readyToExecute chan chan struct{}) *
 	gceDriver := GetGCEDriver()
 	mounter := mountmanager.NewFakeSafeBlockingMounter(readyToExecute)
 	nodeServer := NewNodeServer(gceDriver, mounter, mountmanager.NewFakeDeviceUtils(), metadataservice.NewFakeService(), mountmanager.NewFakeStatter(mounter))
-	err := gceDriver.SetupGCEDriver(driver, "test-vendor", nil, nil, nodeServer)
+	err := gceDriver.SetupGCEDriver(driver, "test-vendor", nil, nil, nil, nodeServer)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -39,6 +39,7 @@ func TestSanity(t *testing.T) {
 	zone := "country-region-zone"
 	vendorVersion := "test-version"
 	tmpDir := "/tmp/csi"
+	extraLabels := map[string]string{"test-label": "test-label-value"}
 	endpoint := fmt.Sprintf("unix:%s/csi.sock", tmpDir)
 	mountPath := path.Join(tmpDir, "mount")
 	stagePath := path.Join(tmpDir, "stage")
@@ -57,7 +58,7 @@ func TestSanity(t *testing.T) {
 	identityServer := driver.NewIdentityServer(gceDriver)
 	controllerServer := driver.NewControllerServer(gceDriver, cloudProvider)
 	nodeServer := driver.NewNodeServer(gceDriver, mounter, deviceUtils, metadataservice.NewFakeService(), mountmanager.NewFakeStatter(mounter))
-	err = gceDriver.SetupGCEDriver(driverName, vendorVersion, identityServer, controllerServer, nodeServer)
+	err = gceDriver.SetupGCEDriver(driverName, vendorVersion, extraLabels, identityServer, controllerServer, nodeServer)
 	if err != nil {
 		t.Fatalf("Failed to initialize GCE CSI Driver: %v", err)
 	}

--- a/vendor/k8s.io/component-base/LICENSE
+++ b/vendor/k8s.io/component-base/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/component-base/cli/flag/ciphersuites_flag.go
+++ b/vendor/k8s.io/component-base/cli/flag/ciphersuites_flag.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// ciphers maps strings into tls package cipher constants in
+// https://golang.org/pkg/crypto/tls/#pkg-constants
+var ciphers = map[string]uint16{
+	"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+}
+
+func TLSCipherPossibleValues() []string {
+	cipherKeys := sets.NewString()
+	for key := range ciphers {
+		cipherKeys.Insert(key)
+	}
+	return cipherKeys.List()
+}
+
+func TLSCipherSuites(cipherNames []string) ([]uint16, error) {
+	if len(cipherNames) == 0 {
+		return nil, nil
+	}
+	ciphersIntSlice := make([]uint16, 0)
+	for _, cipher := range cipherNames {
+		intValue, ok := ciphers[cipher]
+		if !ok {
+			return nil, fmt.Errorf("Cipher suite %s not supported or doesn't exist", cipher)
+		}
+		ciphersIntSlice = append(ciphersIntSlice, intValue)
+	}
+	return ciphersIntSlice, nil
+}
+
+var versions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+func TLSPossibleVersions() []string {
+	versionsKeys := sets.NewString()
+	for key := range versions {
+		versionsKeys.Insert(key)
+	}
+	return versionsKeys.List()
+}
+
+func TLSVersion(versionName string) (uint16, error) {
+	if len(versionName) == 0 {
+		return DefaultTLSVersion(), nil
+	}
+	if version, ok := versions[versionName]; ok {
+		return version, nil
+	}
+	return 0, fmt.Errorf("unknown tls version %q", versionName)
+}
+
+func DefaultTLSVersion() uint16 {
+	// Can't use SSLv3 because of POODLE and BEAST
+	// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+	// Can't use TLSv1.1 because of RC4 cipher usage
+	return tls.VersionTLS12
+}

--- a/vendor/k8s.io/component-base/cli/flag/colon_separated_multimap_string_string.go
+++ b/vendor/k8s.io/component-base/cli/flag/colon_separated_multimap_string_string.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ColonSeparatedMultimapStringString supports setting a map[string][]string from an encoding
+// that separates keys from values with ':' and separates key-value pairs with ','.
+// A key can be repeated multiple times, in which case the values are appended to a
+// slice of strings associated with that key. Items in the list associated with a given
+// key will appear in the order provided.
+// For example: `a:hello,b:again,c:world,b:beautiful` results in `{"a": ["hello"], "b": ["again", "beautiful"], "c": ["world"]}`
+// The first call to Set will clear the map before adding entries; subsequent calls will simply append to the map.
+// This makes it possible to override default values with a command-line option rather than appending to defaults,
+// while still allowing the distribution of key-value pairs across multiple flag invocations.
+// For example: `--flag "a:hello" --flag "b:again" --flag "b:beautiful" --flag "c:world"` results in `{"a": ["hello"], "b": ["again", "beautiful"], "c": ["world"]}`
+type ColonSeparatedMultimapStringString struct {
+	Multimap    *map[string][]string
+	initialized bool // set to true after the first Set call
+}
+
+// NewColonSeparatedMultimapStringString takes a pointer to a map[string][]string and returns the
+// ColonSeparatedMultimapStringString flag parsing shim for that map.
+func NewColonSeparatedMultimapStringString(m *map[string][]string) *ColonSeparatedMultimapStringString {
+	return &ColonSeparatedMultimapStringString{Multimap: m}
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *ColonSeparatedMultimapStringString) Set(value string) error {
+	if m.Multimap == nil {
+		return fmt.Errorf("no target (nil pointer to map[string][]string)")
+	}
+	if !m.initialized || *m.Multimap == nil {
+		// clear default values, or allocate if no existing map
+		*m.Multimap = make(map[string][]string)
+		m.initialized = true
+	}
+	for _, pair := range strings.Split(value, ",") {
+		if len(pair) == 0 {
+			continue
+		}
+		kv := strings.SplitN(pair, ":", 2)
+		if len(kv) != 2 {
+			return fmt.Errorf("malformed pair, expect string:string")
+		}
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
+		(*m.Multimap)[k] = append((*m.Multimap)[k], v)
+	}
+	return nil
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *ColonSeparatedMultimapStringString) String() string {
+	type kv struct {
+		k string
+		v string
+	}
+	kvs := make([]kv, 0, len(*m.Multimap))
+	for k, vs := range *m.Multimap {
+		for i := range vs {
+			kvs = append(kvs, kv{k: k, v: vs[i]})
+		}
+	}
+	// stable sort by keys, order of values should be preserved
+	sort.SliceStable(kvs, func(i, j int) bool {
+		return kvs[i].k < kvs[j].k
+	})
+	pairs := make([]string, 0, len(kvs))
+	for i := range kvs {
+		pairs = append(pairs, fmt.Sprintf("%s:%s", kvs[i].k, kvs[i].v))
+	}
+	return strings.Join(pairs, ",")
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (m *ColonSeparatedMultimapStringString) Type() string {
+	return "colonSeparatedMultimapStringString"
+}
+
+// Empty implements OmitEmpty
+func (m *ColonSeparatedMultimapStringString) Empty() bool {
+	return len(*m.Multimap) == 0
+}

--- a/vendor/k8s.io/component-base/cli/flag/configuration_map.go
+++ b/vendor/k8s.io/component-base/cli/flag/configuration_map.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type ConfigurationMap map[string]string
+
+func (m *ConfigurationMap) String() string {
+	pairs := []string{}
+	for k, v := range *m {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+func (m *ConfigurationMap) Set(value string) error {
+	for _, s := range strings.Split(value, ",") {
+		if len(s) == 0 {
+			continue
+		}
+		arr := strings.SplitN(s, "=", 2)
+		if len(arr) == 2 {
+			(*m)[strings.TrimSpace(arr[0])] = strings.TrimSpace(arr[1])
+		} else {
+			(*m)[strings.TrimSpace(arr[0])] = ""
+		}
+	}
+	return nil
+}
+
+func (*ConfigurationMap) Type() string {
+	return "mapStringString"
+}

--- a/vendor/k8s.io/component-base/cli/flag/flags.go
+++ b/vendor/k8s.io/component-base/cli/flag/flags.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	goflag "flag"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"k8s.io/klog"
+)
+
+// WordSepNormalizeFunc changes all flags that contain "_" separators
+func WordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	if strings.Contains(name, "_") {
+		return pflag.NormalizedName(strings.Replace(name, "_", "-", -1))
+	}
+	return pflag.NormalizedName(name)
+}
+
+// WarnWordSepNormalizeFunc changes and warns for flags that contain "_" separators
+func WarnWordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	if strings.Contains(name, "_") {
+		nname := strings.Replace(name, "_", "-", -1)
+		klog.Warningf("%s is DEPRECATED and will be removed in a future version. Use %s instead.", name, nname)
+
+		return pflag.NormalizedName(nname)
+	}
+	return pflag.NormalizedName(name)
+}
+
+// InitFlags normalizes, parses, then logs the command line flags
+func InitFlags() {
+	pflag.CommandLine.SetNormalizeFunc(WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	pflag.Parse()
+	pflag.VisitAll(func(flag *pflag.Flag) {
+		klog.V(2).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
+}

--- a/vendor/k8s.io/component-base/cli/flag/langle_separated_map_string_string.go
+++ b/vendor/k8s.io/component-base/cli/flag/langle_separated_map_string_string.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// LangleSeparatedMapStringString can be set from the command line with the format `--flag "string<string"`.
+// Multiple comma-separated key-value pairs in a single invocation are supported. For example: `--flag "a<foo,b<bar"`.
+// Multiple flag invocations are supported. For example: `--flag "a<foo" --flag "b<foo"`.
+type LangleSeparatedMapStringString struct {
+	Map         *map[string]string
+	initialized bool // set to true after first Set call
+}
+
+// NewLangleSeparatedMapStringString takes a pointer to a map[string]string and returns the
+// LangleSeparatedMapStringString flag parsing shim for that map
+func NewLangleSeparatedMapStringString(m *map[string]string) *LangleSeparatedMapStringString {
+	return &LangleSeparatedMapStringString{Map: m}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *LangleSeparatedMapStringString) String() string {
+	pairs := []string{}
+	for k, v := range *m.Map {
+		pairs = append(pairs, fmt.Sprintf("%s<%s", k, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *LangleSeparatedMapStringString) Set(value string) error {
+	if m.Map == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]string)")
+	}
+	if !m.initialized || *m.Map == nil {
+		// clear default values, or allocate if no existing map
+		*m.Map = make(map[string]string)
+		m.initialized = true
+	}
+	for _, s := range strings.Split(value, ",") {
+		if len(s) == 0 {
+			continue
+		}
+		arr := strings.SplitN(s, "<", 2)
+		if len(arr) != 2 {
+			return fmt.Errorf("malformed pair, expect string<string")
+		}
+		k := strings.TrimSpace(arr[0])
+		v := strings.TrimSpace(arr[1])
+		(*m.Map)[k] = v
+	}
+	return nil
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*LangleSeparatedMapStringString) Type() string {
+	return "mapStringString"
+}
+
+// Empty implements OmitEmpty
+func (m *LangleSeparatedMapStringString) Empty() bool {
+	return len(*m.Map) == 0
+}

--- a/vendor/k8s.io/component-base/cli/flag/map_string_bool.go
+++ b/vendor/k8s.io/component-base/cli/flag/map_string_bool.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// MapStringBool can be set from the command line with the format `--flag "string=bool"`.
+// Multiple comma-separated key-value pairs in a single invocation are supported. For example: `--flag "a=true,b=false"`.
+// Multiple flag invocations are supported. For example: `--flag "a=true" --flag "b=false"`.
+type MapStringBool struct {
+	Map         *map[string]bool
+	initialized bool
+}
+
+// NewMapStringBool takes a pointer to a map[string]string and returns the
+// MapStringBool flag parsing shim for that map
+func NewMapStringBool(m *map[string]bool) *MapStringBool {
+	return &MapStringBool{Map: m}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *MapStringBool) String() string {
+	if m == nil || m.Map == nil {
+		return ""
+	}
+	pairs := []string{}
+	for k, v := range *m.Map {
+		pairs = append(pairs, fmt.Sprintf("%s=%t", k, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *MapStringBool) Set(value string) error {
+	if m.Map == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]bool)")
+	}
+	if !m.initialized || *m.Map == nil {
+		// clear default values, or allocate if no existing map
+		*m.Map = make(map[string]bool)
+		m.initialized = true
+	}
+	for _, s := range strings.Split(value, ",") {
+		if len(s) == 0 {
+			continue
+		}
+		arr := strings.SplitN(s, "=", 2)
+		if len(arr) != 2 {
+			return fmt.Errorf("malformed pair, expect string=bool")
+		}
+		k := strings.TrimSpace(arr[0])
+		v := strings.TrimSpace(arr[1])
+		boolValue, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("invalid value of %s: %s, err: %v", k, v, err)
+		}
+		(*m.Map)[k] = boolValue
+	}
+	return nil
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*MapStringBool) Type() string {
+	return "mapStringBool"
+}
+
+// Empty implements OmitEmpty
+func (m *MapStringBool) Empty() bool {
+	return len(*m.Map) == 0
+}

--- a/vendor/k8s.io/component-base/cli/flag/map_string_string.go
+++ b/vendor/k8s.io/component-base/cli/flag/map_string_string.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MapStringString can be set from the command line with the format `--flag "string=string"`.
+// Multiple flag invocations are supported. For example: `--flag "a=foo" --flag "b=bar"`. If this is desired
+// to be the only type invocation `NoSplit` should be set to true.
+// Multiple comma-separated key-value pairs in a single invocation are supported if `NoSplit`
+// is set to false. For example: `--flag "a=foo,b=bar"`.
+type MapStringString struct {
+	Map         *map[string]string
+	initialized bool
+	NoSplit     bool
+}
+
+// NewMapStringString takes a pointer to a map[string]string and returns the
+// MapStringString flag parsing shim for that map
+func NewMapStringString(m *map[string]string) *MapStringString {
+	return &MapStringString{Map: m}
+}
+
+// NewMapStringString takes a pointer to a map[string]string and sets `NoSplit`
+// value to `true` and returns the MapStringString flag parsing shim for that map
+func NewMapStringStringNoSplit(m *map[string]string) *MapStringString {
+	return &MapStringString{
+		Map:     m,
+		NoSplit: true,
+	}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *MapStringString) String() string {
+	if m == nil || m.Map == nil {
+		return ""
+	}
+	pairs := []string{}
+	for k, v := range *m.Map {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *MapStringString) Set(value string) error {
+	if m.Map == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]string)")
+	}
+	if !m.initialized || *m.Map == nil {
+		// clear default values, or allocate if no existing map
+		*m.Map = make(map[string]string)
+		m.initialized = true
+	}
+
+	// account for comma-separated key-value pairs in a single invocation
+	if !m.NoSplit {
+		for _, s := range strings.Split(value, ",") {
+			if len(s) == 0 {
+				continue
+			}
+			arr := strings.SplitN(s, "=", 2)
+			if len(arr) != 2 {
+				return fmt.Errorf("malformed pair, expect string=string")
+			}
+			k := strings.TrimSpace(arr[0])
+			v := strings.TrimSpace(arr[1])
+			(*m.Map)[k] = v
+		}
+		return nil
+	}
+
+	// account for only one key-value pair in a single invocation
+	arr := strings.SplitN(value, "=", 2)
+	if len(arr) != 2 {
+		return fmt.Errorf("malformed pair, expect string=string")
+	}
+	k := strings.TrimSpace(arr[0])
+	v := strings.TrimSpace(arr[1])
+	(*m.Map)[k] = v
+	return nil
+
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*MapStringString) Type() string {
+	return "mapStringString"
+}
+
+// Empty implements OmitEmpty
+func (m *MapStringString) Empty() bool {
+	return len(*m.Map) == 0
+}

--- a/vendor/k8s.io/component-base/cli/flag/namedcertkey_flag.go
+++ b/vendor/k8s.io/component-base/cli/flag/namedcertkey_flag.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"errors"
+	"flag"
+	"strings"
+)
+
+// NamedCertKey is a flag value parsing "certfile,keyfile" and "certfile,keyfile:name,name,name".
+type NamedCertKey struct {
+	Names             []string
+	CertFile, KeyFile string
+}
+
+var _ flag.Value = &NamedCertKey{}
+
+func (nkc *NamedCertKey) String() string {
+	s := nkc.CertFile + "," + nkc.KeyFile
+	if len(nkc.Names) > 0 {
+		s = s + ":" + strings.Join(nkc.Names, ",")
+	}
+	return s
+}
+
+func (nkc *NamedCertKey) Set(value string) error {
+	cs := strings.SplitN(value, ":", 2)
+	var keycert string
+	if len(cs) == 2 {
+		var names string
+		keycert, names = strings.TrimSpace(cs[0]), strings.TrimSpace(cs[1])
+		if names == "" {
+			return errors.New("empty names list is not allowed")
+		}
+		nkc.Names = nil
+		for _, name := range strings.Split(names, ",") {
+			nkc.Names = append(nkc.Names, strings.TrimSpace(name))
+		}
+	} else {
+		nkc.Names = nil
+		keycert = strings.TrimSpace(cs[0])
+	}
+	cs = strings.Split(keycert, ",")
+	if len(cs) != 2 {
+		return errors.New("expected comma separated certificate and key file paths")
+	}
+	nkc.CertFile = strings.TrimSpace(cs[0])
+	nkc.KeyFile = strings.TrimSpace(cs[1])
+	return nil
+}
+
+func (*NamedCertKey) Type() string {
+	return "namedCertKey"
+}
+
+// NamedCertKeyArray is a flag value parsing NamedCertKeys, each passed with its own
+// flag instance (in contrast to comma separated slices).
+type NamedCertKeyArray struct {
+	value   *[]NamedCertKey
+	changed bool
+}
+
+var _ flag.Value = &NamedCertKey{}
+
+// NewNamedKeyCertArray creates a new NamedCertKeyArray with the internal value
+// pointing to p.
+func NewNamedCertKeyArray(p *[]NamedCertKey) *NamedCertKeyArray {
+	return &NamedCertKeyArray{
+		value: p,
+	}
+}
+
+func (a *NamedCertKeyArray) Set(val string) error {
+	nkc := NamedCertKey{}
+	err := nkc.Set(val)
+	if err != nil {
+		return err
+	}
+	if !a.changed {
+		*a.value = []NamedCertKey{nkc}
+		a.changed = true
+	} else {
+		*a.value = append(*a.value, nkc)
+	}
+	return nil
+}
+
+func (a *NamedCertKeyArray) Type() string {
+	return "namedCertKey"
+}
+
+func (a *NamedCertKeyArray) String() string {
+	nkcs := make([]string, 0, len(*a.value))
+	for i := range *a.value {
+		nkcs = append(nkcs, (*a.value)[i].String())
+	}
+	return "[" + strings.Join(nkcs, ";") + "]"
+}

--- a/vendor/k8s.io/component-base/cli/flag/noop.go
+++ b/vendor/k8s.io/component-base/cli/flag/noop.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	goflag "flag"
+	"github.com/spf13/pflag"
+)
+
+// NoOp implements goflag.Value and plfag.Value,
+// but has a noop Set implementation
+type NoOp struct{}
+
+var _ goflag.Value = NoOp{}
+var _ pflag.Value = NoOp{}
+
+func (NoOp) String() string {
+	return ""
+}
+
+func (NoOp) Set(val string) error {
+	return nil
+}
+
+func (NoOp) Type() string {
+	return "NoOp"
+}

--- a/vendor/k8s.io/component-base/cli/flag/omitempty.go
+++ b/vendor/k8s.io/component-base/cli/flag/omitempty.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+// OmitEmpty is an interface for flags to report whether their underlying value
+// is "empty." If a flag implements OmitEmpty and returns true for a call to Empty(),
+// it is assumed that flag may be omitted from the command line.
+type OmitEmpty interface {
+	Empty() bool
+}

--- a/vendor/k8s.io/component-base/cli/flag/sectioned.go
+++ b/vendor/k8s.io/component-base/cli/flag/sectioned.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// NamedFlagSets stores named flag sets in the order of calling FlagSet.
+type NamedFlagSets struct {
+	// Order is an ordered list of flag set names.
+	Order []string
+	// FlagSets stores the flag sets by name.
+	FlagSets map[string]*pflag.FlagSet
+}
+
+// FlagSet returns the flag set with the given name and adds it to the
+// ordered name list if it is not in there yet.
+func (nfs *NamedFlagSets) FlagSet(name string) *pflag.FlagSet {
+	if nfs.FlagSets == nil {
+		nfs.FlagSets = map[string]*pflag.FlagSet{}
+	}
+	if _, ok := nfs.FlagSets[name]; !ok {
+		nfs.FlagSets[name] = pflag.NewFlagSet(name, pflag.ExitOnError)
+		nfs.Order = append(nfs.Order, name)
+	}
+	return nfs.FlagSets[name]
+}
+
+// PrintSections prints the given names flag sets in sections, with the maximal given column number.
+// If cols is zero, lines are not wrapped.
+func PrintSections(w io.Writer, fss NamedFlagSets, cols int) {
+	for _, name := range fss.Order {
+		fs := fss.FlagSets[name]
+		if !fs.HasFlags() {
+			continue
+		}
+
+		wideFS := pflag.NewFlagSet("", pflag.ExitOnError)
+		wideFS.AddFlagSet(fs)
+
+		var zzz string
+		if cols > 24 {
+			zzz = strings.Repeat("z", cols-24)
+			wideFS.Int(zzz, 0, strings.Repeat("z", cols-24))
+		}
+
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "\n%s flags:\n\n%s", strings.ToUpper(name[:1])+name[1:], wideFS.FlagUsagesWrapped(cols))
+
+		if cols > 24 {
+			i := strings.Index(buf.String(), zzz)
+			lines := strings.Split(buf.String()[:i], "\n")
+			fmt.Fprint(w, strings.Join(lines[:len(lines)-1], "\n"))
+			fmt.Fprintln(w)
+		} else {
+			fmt.Fprint(w, buf.String())
+		}
+	}
+}

--- a/vendor/k8s.io/component-base/cli/flag/string_flag.go
+++ b/vendor/k8s.io/component-base/cli/flag/string_flag.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+// StringFlag is a string flag compatible with flags and pflags that keeps track of whether it had a value supplied or not.
+type StringFlag struct {
+	// If Set has been invoked this value is true
+	provided bool
+	// The exact value provided on the flag
+	value string
+}
+
+func NewStringFlag(defaultVal string) StringFlag {
+	return StringFlag{value: defaultVal}
+}
+
+func (f *StringFlag) Default(value string) {
+	f.value = value
+}
+
+func (f StringFlag) String() string {
+	return f.value
+}
+
+func (f StringFlag) Value() string {
+	return f.value
+}
+
+func (f *StringFlag) Set(value string) error {
+	f.value = value
+	f.provided = true
+
+	return nil
+}
+
+func (f StringFlag) Provided() bool {
+	return f.provided
+}
+
+func (f *StringFlag) Type() string {
+	return "string"
+}

--- a/vendor/k8s.io/component-base/cli/flag/tristate.go
+++ b/vendor/k8s.io/component-base/cli/flag/tristate.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Tristate is a flag compatible with flags and pflags that
+// keeps track of whether it had a value supplied or not.
+type Tristate int
+
+const (
+	Unset Tristate = iota // 0
+	True
+	False
+)
+
+func (f *Tristate) Default(value bool) {
+	*f = triFromBool(value)
+}
+
+func (f Tristate) String() string {
+	b := boolFromTri(f)
+	return fmt.Sprintf("%t", b)
+}
+
+func (f Tristate) Value() bool {
+	b := boolFromTri(f)
+	return b
+}
+
+func (f *Tristate) Set(value string) error {
+	boolVal, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+
+	*f = triFromBool(boolVal)
+	return nil
+}
+
+func (f Tristate) Provided() bool {
+	if f != Unset {
+		return true
+	}
+	return false
+}
+
+func (f *Tristate) Type() string {
+	return "tristate"
+}
+
+func boolFromTri(t Tristate) bool {
+	if t == True {
+		return true
+	} else {
+		return false
+	}
+}
+
+func triFromBool(b bool) Tristate {
+	if b {
+		return True
+	} else {
+		return False
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -462,6 +462,8 @@ k8s.io/client-go/util/homedir
 k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/workqueue
+# k8s.io/component-base v0.18.0 => k8s.io/component-base v0.18.0
+k8s.io/component-base/cli/flag
 # k8s.io/klog v1.0.0
 k8s.io/klog
 # k8s.io/kubernetes v1.18.0


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Allow to optionally label the PD disk with extra labels.This allows e.g. better automated resource cleanup on cluster teardown.
This is related to https://bugzilla.redhat.com/show_bug.cgi?id=1895028

**Does this PR introduce a user-facing change?**:
```release-note
A new `extra-labels` command line option has been added allowing for additional labels to be attached to the each PD created.
```