### PR TITLE
Verify that tests correctly handle rounding on 4GiB boundaries

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -70,8 +70,9 @@ func BytesToGbRoundDown(bytes int64) int64 {
 }
 
 func BytesToGbRoundUp(bytes int64) int64 {
-	re := bytes / (1024 * 1024 * 1024)
-	if (bytes % (1024 * 1024 * 1024)) != 0 {
+	// TEST: verify that rounding to 4GiB works correctly
+	re := bytes / (1024 * 1024 * 1024 * 4)
+	if (bytes % (1024 * 1024 * 1024 * 4)) != 0 {
 		re++
 	}
 	return re

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -75,7 +75,7 @@ func BytesToGbRoundUp(bytes int64) int64 {
 	if (bytes % (1024 * 1024 * 1024 * 4)) != 0 {
 		re++
 	}
-	return re
+	return 4 * re
 }
 
 func GbToBytes(Gb int64) int64 {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Verify that [PR #199](https://github.com/kubernetes-csi/external-provisioner/issues/199) addresses [Issue #94128](https://github.com/kubernetes/kubernetes/issues/94128) by changing the GCP rounding to use a 4GiB aligned value. The GCP  CSI driver is used because it contains a common method for rounding that is easy to modify for testing.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This is a test PR and will not be merged. It is being used to run the test suites to verify that an existing fix works as expected.

**Does this PR introduce a user-facing change?**:
```release-note
None
```
