### PR TITLE
Bug 2052955: Disable uuid checks on XFS

### DIFF
--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -132,10 +132,7 @@ func (ns *GCENodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePub
 		}
 
 		klog.V(4).Infof("NodePublishVolume with filesystem %s", fstype)
-
-		for _, flag := range mnt.MountFlags {
-			options = append(options, flag)
-		}
+		options = append(options, collectMountOptions(fstype, mnt.MountFlags)...)
 
 		sourcePath = stagingTargetPath
 		if err := preparePublishPath(targetPath, ns.Mounter); err != nil {
@@ -308,9 +305,7 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 		if mnt.FsType != "" {
 			fstype = mnt.FsType
 		}
-		for _, flag := range mnt.MountFlags {
-			options = append(options, flag)
-		}
+		options = collectMountOptions(fstype, mnt.MountFlags)
 	} else if blk := volumeCapability.GetBlock(); blk != nil {
 		// Noop for Block NodeStageVolume
 		klog.V(4).Infof("NodeStageVolume succeeded on %v to %s, capability is block so this is a no-op", volumeID, stagingTargetPath)

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -27,6 +27,10 @@ import (
 	"k8s.io/klog"
 )
 
+const (
+	fsTypeXFS = "xfs"
+)
+
 func NewVolumeCapabilityAccessMode(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability_AccessMode {
 	return &csi.VolumeCapability_AccessMode{Mode: mode}
 }
@@ -146,4 +150,19 @@ func getMultiWriterFromCapabilities(vcs []*csi.VolumeCapability) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func collectMountOptions(fsType string, mntFlags []string) []string {
+	var options []string
+
+	for _, opt := range mntFlags {
+		options = append(options, opt)
+	}
+
+	// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
+	// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
+	if fsType == fsTypeXFS {
+		options = append(options, "nouuid")
+	}
+	return options
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

Upstream PR: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/788

**What this PR does / why we need it**:
By default, XFS does not allow mounting two devices that have the same UUID
of the XFS filesystem. Therefore it's not possible to mount a volume + its
restored snapshot.

Therefore disable UUID check in XFS using a mount option

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
It is now possible to mount a volume with XFS filesystem and its restored snapshot.
```
