### PR TITLE
Bug 1877261: UPSTREAM: 973: filesystem is not resized when restoring

### DIFF
--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -339,6 +339,15 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 				devicePath, stagingTargetPath, fstype, options, err.Error()))
 	}
 
+	// Part 4: Resize filesystem.
+	// https://github.com/kubernetes/kubernetes/issues/94929
+	resizer := resizefs.NewResizeFs(ns.Mounter)
+	_, err = resizer.Resize(devicePath, stagingTargetPath)
+	if err != nil {
+		return nil, status.Error(codes.Internal, fmt.Sprintf("error when resizing volume %s: %v", volumeID, err))
+
+	}
+
 	klog.V(4).Infof("NodeStageVolume succeeded on %v to %s", volumeID, stagingTargetPath)
 	return &csi.NodeStageVolumeResponse{}, nil
 }

--- a/pkg/resizefs/resizefs_linux.go
+++ b/pkg/resizefs/resizefs_linux.go
@@ -19,7 +19,8 @@ limitations under the License.
 package resizefs
 
 import (
-	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
@@ -38,51 +39,22 @@ func NewResizeFs(mounter *mount.SafeFormatAndMount) *resizeFs {
 }
 
 // Resize perform resize of file system
-func (resizefs *resizeFs) Resize(devicePath, deviceMountPath string) (bool, error) {
-	format, err := resizefs.mounter.GetDiskFormat(devicePath)
+func (resizefs *resizeFs) Resize(devicePath, deviceMountPath string) (needResize bool, err error) {
+	resizer := mount.NewResizeFs(resizefs.mounter.Exec)
 
-	if err != nil {
-		formatErr := fmt.Errorf("ResizeFS.Resize - error checking format for device %s: %v", devicePath, err)
-		return false, formatErr
+	klog.V(4).Infof("Checking if filesystem needs to be resized. Device: %s Mountpoint: %s", devicePath, deviceMountPath)
+	if needResize, err = resizer.NeedResize(devicePath, deviceMountPath); err != nil {
+		err = status.Errorf(codes.Internal, "Could not determine if filesystem %q needs to be resized: %v", deviceMountPath, err)
+		return
 	}
 
-	// If disk has no format, there is no need to resize the disk because mkfs.*
-	// by default will use whole disk anyways.
-	if format == "" {
-		return false, nil
+	if needResize {
+		klog.V(4).Infof("Resizing filesystem. Device: %s Mountpoint: %s", devicePath, deviceMountPath)
+		if _, err = resizer.Resize(devicePath, deviceMountPath); err != nil {
+			err = status.Errorf(codes.Internal, "Failed to resize filesystem %q: %v", deviceMountPath, err)
+			return
+		}
 	}
 
-	klog.V(3).Infof("ResizeFS.Resize - Expanding mounted volume %s", devicePath)
-	switch format {
-	case "ext3", "ext4":
-		return resizefs.extResize(devicePath)
-	case "xfs":
-		return resizefs.xfsResize(deviceMountPath)
-	}
-	return false, fmt.Errorf("ResizeFS.Resize - resize of format %s is not supported for device %s mounted at %s", format, devicePath, deviceMountPath)
-}
-
-func (resizefs *resizeFs) extResize(devicePath string) (bool, error) {
-	output, err := resizefs.mounter.Exec.Command("resize2fs", devicePath).CombinedOutput()
-	if err == nil {
-		klog.V(2).Infof("Device %s resized successfully", devicePath)
-		return true, nil
-	}
-
-	resizeError := fmt.Errorf("resize of device %s failed: %v. resize2fs output: %s", devicePath, err, string(output))
-	return false, resizeError
-
-}
-
-func (resizefs *resizeFs) xfsResize(deviceMountPath string) (bool, error) {
-	args := []string{"-d", deviceMountPath}
-	output, err := resizefs.mounter.Exec.Command("xfs_growfs", args...).CombinedOutput()
-
-	if err == nil {
-		klog.V(2).Infof("Device %s resized successfully", deviceMountPath)
-		return true, nil
-	}
-
-	resizeError := fmt.Errorf("resize of device %s failed: %v. xfs_growfs output: %s", deviceMountPath, err, string(output))
-	return false, resizeError
+	return
 }

--- a/test/e2e/tests/resize_e2e_test.go
+++ b/test/e2e/tests/resize_e2e_test.go
@@ -232,17 +232,12 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			}
 		}()
 
-		// Verify pre-resize fs size
-		sizeGb, err := testutils.GetFSSizeInGb(instance, publishDir)
-		Expect(err).To(BeNil(), "Failed to get FSSize in GB")
-		Expect(sizeGb).To(Equal(defaultSizeGb))
-
 		// Resize node
 		_, err = client.NodeExpandVolume(volID, publishDir, newSizeGb)
 		Expect(err).To(BeNil(), "Node expand volume failed")
 
 		// Verify disk size
-		sizeGb, err = testutils.GetFSSizeInGb(instance, publishDir)
+		sizeGb, err := testutils.GetFSSizeInGb(instance, publishDir)
 		Expect(err).To(BeNil(), "Failed to get FSSize in GB")
 		Expect(sizeGb).To(Equal(newSizeGb))
 


### PR DESCRIPTION
This is a cherry-pick of: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/972

Required for OCP 4.13: https://issues.redhat.com/browse/OCPBUGSM-17094