### PR TITLE
WIP: DO_NOT_MERGE: lets see if `e2e-gcp-ovn-upgrade` can succeed

### DIFF
--- a/pkg/gce-pd-csi-driver/server.go
+++ b/pkg/gce-pd-csi-driver/server.go
@@ -12,6 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Dummy change
+
 package gceGCEDriver
 
 import (


### PR DESCRIPTION
The test failed in [PR#43](https://github.com/openshift/gcp-pd-csi-driver/pull/43) in a weird way:

```
: [sig-network] pods should successfully create sandboxes by other expand_less	0s
{  4 failures to create the sandbox

ns/openshift-multus pod/network-metrics-daemon-g6bfz node/ci-op-2nhnsc00-68b78-bvcsp-master-2 - never deleted - reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_network-metrics-daemon-g6bfz_openshift-multus_7cae7166-28f2-4a44-8d70-f7fc88768a2e_0(fa006873692b278d2781a04f857b0fe1b3b41b5e6d902eaab070aa6faa1c5d7c): No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?
ns/openshift-multus pod/network-metrics-daemon-8k972 node/ci-op-2nhnsc00-68b78-bvcsp-worker-a-npfls - never deleted - network rollout - reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_network-metrics-daemon-8k972_openshift-multus_685cd1f9-4d25-4f43-baf0-ac8cf5b77e03_0(2562a70b4b0836019fd8d3c49581738ac4283617ec200e61d66bd2542398234a): No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?
ns/openshift-multus pod/network-metrics-daemon-8k972 node/ci-op-2nhnsc00-68b78-bvcsp-worker-a-npfls - never deleted - network rollout - reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_network-metrics-daemon-8k972_openshift-multus_685cd1f9-4d25-4f43-baf0-ac8cf5b77e03_0(bce5315b9c0614bdac07a21b14b6f17837a1a422194b4fec88eed2a53ef846ec): No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?
ns/openshift-multus pod/network-metrics-daemon-g6bfz node/ci-op-2nhnsc00-68b78-bvcsp-master-2 - never deleted - network rollout - reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_network-metrics-daemon-g6bfz_openshift-multus_7cae7166-28f2-4a44-8d70-f7fc88768a2e_0(80e40d0a13bba6a80c4180f1effe23e3aebd540b303bfc9fe4aaa75c7ad87a68): No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?}
```
(https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_gcp-pd-csi-driver/43/pull-ci-openshift-gcp-pd-csi-driver-master-e2e-gcp-ovn-upgrade/1713960611647328256)

Let's see if it succeeds in this PR.