### PR TITLE
OCPBUGS-59749: 4.19: UPSTREAM: 2116: Remove check on snapshot create support for multi-writer HyperDisk-HA and let such validations occur at the PD control plane layer

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1588,9 +1588,6 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 		}
 		return nil, common.LoggedError("CreateSnapshot, failed to getDisk: ", err)
 	}
-	if common.IsHyperdisk(disk.GetPDType()) && disk.GetAccessMode() == common.GCEReadWriteManyAccessMode {
-		return nil, status.Errorf(codes.InvalidArgument, "Cannot create snapshot for disk type %s with access mode %s", common.DiskTypeHdHA, common.GCEReadWriteManyAccessMode)
-	}
 
 	snapshotParams, err := common.ExtractAndDefaultSnapshotParameters(req.GetParameters(), gceCS.Driver.name, gceCS.Driver.extraTags)
 	if err != nil {

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -265,24 +265,6 @@ func TestCreateSnapshotArguments(t *testing.T) {
 				ReadyToUse:     false,
 			},
 		},
-		{
-			name: "fail to create snapshot for HdHA multi-writer",
-			req: &csi.CreateSnapshotRequest{
-				Name:           name,
-				SourceVolumeId: testRegionalID,
-				Parameters:     map[string]string{common.ParameterKeyStorageLocations: " US-WEST2"},
-			},
-			seedDisks: []*gce.CloudDisk{
-				gce.CloudDiskFromV1(&compute.Disk{
-					Name:       name,
-					SelfLink:   fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/project/regions/country-region/name/%s", name),
-					Type:       common.DiskTypeHdHA,
-					AccessMode: common.GCEReadWriteManyAccessMode,
-					Region:     "country-region",
-				}),
-			},
-			expErrCode: codes.InvalidArgument,
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Cherry-pick of upstream PR.
[kubernetes-sigs#2116](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2116/commits) Remove check on snapshot create support for multi-writer HyperDisk-HA